### PR TITLE
Remove warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,6 @@ Despite the fact Plone, and Zope, have their codebases tested with `unittest`, o
 `pytest` became the most popular choice for testing in Python.
 
 `pytest` is more flexible and easier to use than `unittest` and has a rich ecosystem of plugins that you can use to extend its functionality.
-## Warning
-
-**THIS PACKAGE IS NOT CONSIDERED TO BE STABLE AND FIXTURES COULD CHANGE BEFORE A FINAL RELEASE**
 
 ## Usage
 

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
     ],
     extras_require={
         "test": [
+            "Products.CMFPlone[test]",
             "zest.releaser[recommended]",
             "zestreleaser.towncrier",
             "pytest-cov",


### PR DESCRIPTION
At this point this is used in enough places that it wouldn't be practical to introduce breaking changes without releasing a new major version.