### PR TITLE
Add @pytest.mark.portal marker support (#37)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,13 +13,13 @@ jobs:
     name: "Check for change log entries"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # Fetch all history
           fetch-depth: '0'
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           python-version: ${{ env.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   PYTHON_VERSION: "3.12"
-  PLONE_VERSION: "6.1.1"
+  PLONE_VERSION: "6.1.4"
 
 jobs:
 
@@ -14,10 +14,10 @@ jobs:
     steps:
 
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
 
         - name: Install the latest version of uv
-          uses: astral-sh/setup-uv@v5
+          uses: astral-sh/setup-uv@v8.0.0
           with:
             python-version: ${{ env.PYTHON_VERSION }}
             enable-cache: true
@@ -51,8 +51,7 @@ jobs:
           if: ${{ success() || failure() }}
           id: typing
           run: |
-            make install
-            uv run mypy src
+            uvx mypy src
 
         - name: Report
           if: ${{ success() || failure() }}
@@ -70,6 +69,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
         plone-version: ['6.1-latest', '6.0-latest']
@@ -79,22 +79,17 @@ jobs:
     steps:
 
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
 
         - name: Install the latest version of uv
-          uses: astral-sh/setup-uv@v5
+          uses: astral-sh/setup-uv@v8.0.0
           with:
             python-version: ${{ env.PYTHON_VERSION }}
-            enable-cache: false
-
-        - name: Restore uv cache
-          uses: actions/cache@v4
-          with:
-            path: ${{ env.UV_CACHE_DIR }}
-            key: uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ env.PLONE_VERSION }}-${{ hashFiles('pyproject.toml') }}
-            restore-keys: |
-              uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ env.PLONE_VERSION }}-${{ hashFiles('pyproject.toml') }}
-              uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ env.PLONE_VERSION }}
+            cache-suffix: ${{ env.PLONE_VERSION }}-${{ env.PYTHON_VERSION }}
+            enable-cache: true
+            cache-dependency-glob: |
+              pyproject.toml
+              mx.ini
 
         - name: Install Plone and package
           run: make install
@@ -108,22 +103,17 @@ jobs:
       - test
     steps:
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
 
         - name: Install the latest version of uv
-          uses: astral-sh/setup-uv@v5
+          uses: astral-sh/setup-uv@v8.0.0
           with:
             python-version: ${{ env.PYTHON_VERSION }}
-            enable-cache: false
-
-        - name: Restore uv cache
-          uses: actions/cache@v4
-          with:
-            path: /tmp/.uv-cache
-            key: uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ env.PLONE_VERSION }}-${{ hashFiles('pyproject.toml') }}
-            restore-keys: |
-              uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ env.PLONE_VERSION }}-${{ hashFiles('pyproject.toml') }}
-              uv-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ env.PLONE_VERSION }}
+            cache-suffix: ${{ env.PLONE_VERSION }}-${{ env.PYTHON_VERSION }}
+            enable-cache: true
+            cache-dependency-glob: |
+              pyproject.toml
+              mx.ini
 
         - name: Install Plone and package
           run: make install

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ var/
 constraints*.txt
 requirements*.txt
 .coverage*
+.*_cache/
+
+# Local Claude context (not for sharing)
+.claude/*.local.*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "flake8.args": ["--config=pyproject.toml"],
   "ruff.organizeImports": true,
   "python.terminal.activateEnvironment": true,
   "python.testing.pytestArgs": [
@@ -7,7 +6,10 @@
   ],
   "python.testing.unittestEnabled": false,
   "python.testing.pytestEnabled": true,
+  "python.analysis.extraPaths": [
+    "sources/plone-stubs/src"
+  ],
   "[markdown]": {
     "editor.formatOnSave": false
-  }  
+  }
 }

--- a/Makefile
+++ b/Makefile
@@ -28,10 +28,17 @@ BACKEND_FOLDER=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 ifdef PLONE_VERSION
 PLONE_VERSION := $(PLONE_VERSION)
 else
-PLONE_VERSION := 6.1.1
+PLONE_VERSION := 6.1.4
+endif
+
+ifdef CI
+UV_VENV_ARGS :=
+else
+UV_VENV_ARGS := --python={{ cookiecutter.__supported_versions_python[0] }}
 endif
 
 VENV_FOLDER=$(BACKEND_FOLDER)/.venv
+export VIRTUAL_ENV=$(VENV_FOLDER)
 BIN_FOLDER=$(VENV_FOLDER)/bin
 
 # Environment variables to be exported

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ endif
 ifdef CI
 UV_VENV_ARGS :=
 else
-UV_VENV_ARGS := --python={{ cookiecutter.__supported_versions_python[0] }}
+UV_VENV_ARGS := --python=3.12
 endif
 
 VENV_FOLDER=$(BACKEND_FOLDER)/.venv
@@ -74,7 +74,7 @@ requirements-mxdev.txt: ## Generate constraints file
 
 $(VENV_FOLDER): requirements-mxdev.txt ## Install dependencies
 	@echo "$(GREEN)==> Install environment$(RESET)"
-	@uv venv $(VENV_FOLDER)
+	@if [[ -d "$(VENV_FOLDER)" ]]; then echo "$(YELLOW)==> Environment already exists at $(VENV_FOLDER)$(RESET)"; else uv venv $(UV_VENV_ARGS) $(VENV_FOLDER); fi
 	@uv pip install -r requirements-mxdev.txt
 
 .PHONY: sync

--- a/README.md
+++ b/README.md
@@ -316,6 +316,83 @@ def test_last_version(profile_last_version):
     assert version == "1000"
 
 ```
+
+### apply_profiles
+
+|  |  |
+| --- | --- |
+| Description | Function to apply GenericSetup profiles to a Plone site. |
+| Required Fixture | **integration** |
+| Scope | **Session** |
+
+```python
+def test_with_profile(portal, apply_profiles):
+    """Test that a profile can be applied."""
+    apply_profiles(portal, ["my.addon:testing"])
+```
+
+### create_content
+
+|  |  |
+| --- | --- |
+| Description | Function to create content items in a Plone site as the site owner. |
+| Required Fixture | **integration** |
+| Scope | **Session** |
+
+```python
+def test_with_content(portal, create_content):
+    """Test that content is created."""
+    create_content(portal, [
+        {"type": "Document", "id": "doc1", "title": "A Document"},
+    ])
+    assert "doc1" in portal
+```
+
+### grant_roles
+
+|  |  |
+| --- | --- |
+| Description | Function to grant local roles to the test user on a given context. |
+| Required Fixture | **integration** |
+| Scope | **Session** |
+
+```python
+def test_manager_action(portal, grant_roles):
+    """Test an action that requires Manager role."""
+    grant_roles(portal, ["Manager"])
+    # test user now has Manager role on portal
+```
+
+## Markers
+
+### @pytest.mark.portal
+
+Configure the `portal` fixture with GenericSetup profiles, pre-created content, and/or user roles — without overriding the fixture.
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `profiles` | `list[str]` | GenericSetup profile IDs to apply (e.g. `["my.addon:testing"]`) |
+| `content` | `list[dict]` | Dicts passed as keyword arguments to `plone.api.content.create` |
+| `roles` | `list[str]` | Roles granted to the test user via `plone.api.user.grant_roles` |
+
+Setup is applied in order: **profiles → content → roles**.
+
+```python
+import pytest
+
+
+@pytest.mark.portal(
+    profiles=["my.addon:testing"],
+    content=[{"type": "Document", "id": "doc1", "title": "Doc 1"}],
+    roles=["Manager"],
+)
+def test_something(portal):
+    """Test with custom portal setup."""
+    assert "doc1" in portal
+```
+
+Tests without the marker see no behavior change — fully backwards-compatible.
+
 ## Plugin Development
 
 You need a working `python` environment (system, virtualenv, pyenv, etc) version 3.8 or superior.

--- a/mx.ini
+++ b/mx.ini
@@ -12,9 +12,6 @@ version-overrides =
     zope.pytestlayer>=8.3
     pytest>=8.4.0
 
-; example section to use packages from git
-; [example.contenttype]
-; url = https://github.com/collective/example.contenttype.git
-; pushurl = git@github.com:collective/example.contenttype.git
-; extras = test
-; branch = feature-7
+[plone-stubs]
+url = https://github.com/plone/plone-stubs.git
+pushurl = git@github.com:plone/plone-stubs.git

--- a/mx.ini
+++ b/mx.ini
@@ -11,7 +11,3 @@ version-overrides =
     pytest-plone>=1.0.0a1
     zope.pytestlayer>=8.3
     pytest>=8.4.0
-
-[plone-stubs]
-url = https://github.com/plone/plone-stubs.git
-pushurl = git@github.com:plone/plone-stubs.git

--- a/news/+apply_profiles.feature
+++ b/news/+apply_profiles.feature
@@ -1,0 +1,1 @@
+Added `apply_profiles` session-scoped fixture to apply GenericSetup profiles to a Plone site. @ericof

--- a/news/+ci.internal
+++ b/news/+ci.internal
@@ -1,0 +1,1 @@
+Updated CI workflows: bumped actions/checkout to v6 and astral-sh/setup-uv to v8.0.0, replaced manual cache with setup-uv built-in caching, fixed Makefile venv creation conflict with setup-uv, and added fail-fast: false to test matrix. @ericof

--- a/news/+create_content.feature
+++ b/news/+create_content.feature
@@ -1,0 +1,1 @@
+Added `create_content` session-scoped fixture to create content items in a Plone site as the site owner. @ericof

--- a/news/+grant_roles.feature
+++ b/news/+grant_roles.feature
@@ -1,0 +1,1 @@
+Added `grant_roles` session-scoped fixture to grant local roles to the test user on a given context. @ericof

--- a/news/+housekeeping.internal
+++ b/news/+housekeeping.internal
@@ -1,0 +1,1 @@
+Updated development tooling: bumped Plone version to 6.1.4, added plone-stubs to test dependencies, updated mx.ini and .gitignore. @ericof

--- a/news/+vscode.internal
+++ b/news/+vscode.internal
@@ -1,0 +1,1 @@
+Updated VS Code settings: removed obsolete flake8 config, added plone-stubs to analysis paths. @ericof

--- a/news/37.feature
+++ b/news/37.feature
@@ -1,0 +1,1 @@
+Added `@pytest.mark.portal` marker support for configuring the `portal` fixture with GenericSetup profiles, pre-created content, and user roles. @ericof

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "plone-stubs",
+    "plone-stubs; python_version >= '3.12'",
     "pytest-cov",
     "pytest-xdist",
     "mypy>=1.15.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "plone-stubs; python_version >= '3.12'",
+    "plone-stubs @ git+https://github.com/plone/plone-stubs.git ; python_version >= '3.12'",
     "pytest-cov",
     "pytest-xdist",
     "mypy>=1.15.0",
@@ -67,6 +67,9 @@ plone = "pytest_plone.fixtures"
 
 [tool.uv]
 managed = false
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.hatch.version]
 path = "src/pytest_plone/__init__.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
+    "plone-stubs",
     "pytest-cov",
     "pytest-xdist",
     "mypy>=1.15.0",

--- a/src/pytest_plone/_types.py
+++ b/src/pytest_plone/_types.py
@@ -3,6 +3,7 @@ from plone.app.vocabularies import PermissiveVocabulary
 from plone.app.vocabularies import SlicableVocabulary
 from plone.dexterity.content import DexterityContent
 from plone.dexterity.fti import DexterityFTI
+from Products.CMFPlone.Portal import PloneSite
 from typing import Protocol
 from typing import TypeAlias
 from zope.schema.vocabulary import SimpleVocabulary
@@ -30,3 +31,17 @@ class BehaviorsGetter(Protocol):
 
 class VocabularyGetter(Protocol):
     def __call__(self, name: str, context: Context) -> PloneVocabulary: ...
+
+
+class ProfilesApplier(Protocol):
+    def __call__(self, portal: PloneSite, profiles: list[str]) -> None: ...
+
+
+class ContentCreator(Protocol):
+    def __call__(
+        self, container: DexterityContent | Item, content: list[dict]
+    ) -> None: ...
+
+
+class RolesGranter(Protocol):
+    def __call__(self, context: DexterityContent | Item, roles: list[str]) -> None: ...

--- a/src/pytest_plone/fixtures/__init__.py
+++ b/src/pytest_plone/fixtures/__init__.py
@@ -1,5 +1,6 @@
 """Fixtures provided by pytest-plone."""
 
+from .addons import apply_profiles
 from .addons import browser_layers
 from .addons import controlpanel_actions
 from .addons import installer
@@ -8,23 +9,39 @@ from .addons import setup_tool
 from .base import app
 from .base import http_request
 from .base import portal
+from .content import create_content
 from .content import get_behaviors
 from .content import get_fti
 from .env import generate_mo
+from .security import grant_roles
 from .vocabularies import get_vocabulary
+
+import pytest
 
 
 __all__ = [
     "app",
+    "apply_profiles",
     "browser_layers",
     "controlpanel_actions",
+    "create_content",
     "generate_mo",
     "get_behaviors",
     "get_fti",
     "get_vocabulary",
+    "grant_roles",
     "http_request",
     "installer",
     "portal",
     "profile_last_version",
     "setup_tool",
 ]
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "portal(profiles=None, content=None, roles=None): "
+        "configure the portal fixture with GenericSetup profiles, "
+        "pre-created content, and/or user roles",
+    )

--- a/src/pytest_plone/fixtures/addons.py
+++ b/src/pytest_plone/fixtures/addons.py
@@ -7,6 +7,7 @@ from Products.CMFPlone.controlpanel.browser.quickinstaller import InstallerView
 from Products.CMFPlone.Portal import PloneSite
 from Products.GenericSetup.tool import SetupTool
 from pytest_plone import _types as t
+from pytest_plone.fixtures import markers
 from zope.interface.interface import InterfaceClass
 
 import pytest
@@ -95,3 +96,20 @@ def profile_last_version(setup_tool: SetupTool) -> t.ProfileVersionGetter:
         return version[0] if version else ""
 
     return profile_last_version
+
+
+@pytest.fixture(scope="session")
+def apply_profiles() -> t.ProfilesApplier:
+    """Apply GenericSetup profiles to a Plone site.
+
+    Example usage:
+    ```python
+    def test_with_profile(portal, apply_profiles):
+        apply_profiles(portal, ["my.addon:testing"])
+    ```
+    """
+
+    def func(portal: PloneSite, profiles: list[str]) -> None:
+        markers.apply_profiles(portal, profiles)
+
+    return func

--- a/src/pytest_plone/fixtures/base.py
+++ b/src/pytest_plone/fixtures/base.py
@@ -1,5 +1,6 @@
 """Base fixtures."""
 
+from .markers import apply_portal_marker
 from OFS.Application import Application
 from plone.testing.layer import Layer
 from Products.CMFPlone.Portal import PloneSite
@@ -22,16 +23,29 @@ def app(integration: Layer) -> Application:
 
 
 @pytest.fixture()
-def portal(integration: Layer) -> PloneSite:
+def portal(integration: Layer, request: pytest.FixtureRequest) -> PloneSite:
     """Returns the default Plone Site for an integration Layer.
+
+    Supports ``@pytest.mark.portal`` to apply GenericSetup profiles,
+    create content, and grant roles before the test runs.
 
     Example usage:
     ```python
     def test_portal(self, portal):
         assert portal.title == "Plone site"
+
+    @pytest.mark.portal(
+        profiles=["my.addon:testing"],
+        content=[{"type": "Document", "id": "doc1", "title": "A document"}],
+        roles=["Manager"],
+    )
+    def test_portal_with_marker(self, portal):
+        assert "doc1" in portal
     ```
     """
-    return integration["portal"]
+    portal: PloneSite = integration["portal"]
+    apply_portal_marker(portal, request)
+    return portal
 
 
 @pytest.fixture

--- a/src/pytest_plone/fixtures/content.py
+++ b/src/pytest_plone/fixtures/content.py
@@ -2,8 +2,10 @@
 
 from plone.dexterity.fti import DexterityFTI
 from plone.dexterity.interfaces import IDexterityFTI
+from Products.CMFCore.PortalContent import PortalContent
 from Products.CMFPlone.Portal import PloneSite
 from pytest_plone import _types as t
+from pytest_plone.fixtures import markers
 from zope.component import queryUtility
 
 import pytest
@@ -47,3 +49,23 @@ def get_behaviors(get_fti: t.FTIGetter) -> t.BehaviorsGetter:
         return list(fti.behaviors)
 
     return get_behaviors
+
+
+@pytest.fixture(scope="session")
+def create_content() -> t.ContentCreator:
+    """Create content items in a Plone site as the site owner.
+
+    Example usage:
+    ```python
+    def test_with_content(portal, create_content):
+        create_content(portal, [
+            {"type": "Document", "id": "doc1", "title": "A Document"},
+        ])
+        assert "doc1" in portal
+    ```
+    """
+
+    def func(container: PortalContent, content: list[dict]) -> None:
+        markers.create_content(container, content)
+
+    return func

--- a/src/pytest_plone/fixtures/markers.py
+++ b/src/pytest_plone/fixtures/markers.py
@@ -1,0 +1,61 @@
+"""Marker support for pytest-plone fixtures."""
+
+from plone import api
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import TEST_USER_ID
+from Products.CMFCore.PortalContent import PortalContent
+from Products.CMFPlone.Portal import PloneSite
+from zope.component.hooks import site
+
+import pytest
+
+
+PORTAL_MARKER_NAME: str = "portal"
+
+
+def apply_profiles(portal: PloneSite, profiles: list[str]) -> None:
+    """Apply GenericSetup profiles to a Plone site.
+
+    Each entry can be either ``"my.addon:default"`` or the full
+    ``"profile-my.addon:default"`` form — the ``profile-`` prefix
+    is added automatically when missing.
+    """
+    with site(portal):
+        setup_tool = api.portal.get_tool("portal_setup")
+        for profile_id in profiles:
+            if not profile_id.startswith("profile-"):
+                profile_id = f"profile-{profile_id}"
+            setup_tool.runAllImportStepsFromProfile(profile_id)
+
+
+def create_content(container: PortalContent, content: list[dict]) -> None:
+    """Create content items in a container.
+
+    Each dict in *content* is passed as keyword arguments to
+    ``plone.api.content.create(container=container, **spec)``.
+    """
+    for spec in content:
+        api.content.create(container=container, **spec)
+
+
+def grant_roles(context: PortalContent, roles: list[str]) -> None:
+    """Grant roles to the default test user."""
+    api.user.grant_roles(username=TEST_USER_ID, roles=roles, obj=context)
+
+
+def apply_portal_marker(portal: PloneSite, request: pytest.FixtureRequest) -> None:
+    """Read ``@pytest.mark.portal`` and apply profiles, content, and roles."""
+    marker = request.node.get_closest_marker(PORTAL_MARKER_NAME)
+    if marker is None:
+        return
+    marker_profiles: list[str] = marker.kwargs.get("profiles", [])
+    marker_content: list[dict] = marker.kwargs.get("content", [])
+    marker_roles: list[str] = marker.kwargs.get("roles", [])
+    with site(portal):
+        if marker_profiles:
+            apply_profiles(portal, marker_profiles)
+        if marker_content:
+            with api.env.adopt_user(SITE_OWNER_NAME):
+                create_content(portal, marker_content)
+        if marker_roles:
+            grant_roles(portal, marker_roles)

--- a/src/pytest_plone/fixtures/security.py
+++ b/src/pytest_plone/fixtures/security.py
@@ -1,0 +1,24 @@
+"""Security fixtures."""
+
+from pytest_plone import _types as t
+from pytest_plone.fixtures import markers
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def grant_roles() -> t.RolesGranter:
+    """Grant local roles to the test user on the portal.
+
+    Example usage:
+    ```python
+    def test_manager_action(portal, grant_roles):
+        grant_roles(portal, ["Manager"])
+        # test user now has Manager role on portal
+    ```
+    """
+
+    def func(context: t.Context, roles: list[str]) -> None:
+        markers.grant_roles(context, roles)
+
+    return func

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,12 +34,15 @@ def testdir(pytester: Pytester) -> Pytester:
 
 OUR_FIXTURES = [
     "app",
+    "apply_profiles",
     "browser_layers",
     "controlpanel_actions",
+    "create_content",
     "generate_mo",
     "get_behaviors",
     "get_fti",
     "get_vocabulary",
+    "grant_roles",
     "http_request",
     "installer",
     "portal",

--- a/tests/fixtures/test_marker_portal.py
+++ b/tests/fixtures/test_marker_portal.py
@@ -1,0 +1,169 @@
+"""Tests for @pytest.mark.portal marker support."""
+
+import pytest
+
+
+@pytest.mark.no_cover
+class TestPortalMarkerNoArgs:
+    """Portal fixture works without the marker (backwards-compatible)."""
+
+    def test_portal_without_marker(self, testdir):
+        testdir.makepyfile(
+            """
+            def test_portal_no_marker(portal):
+                assert portal.title == "Plone site"
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=1)
+
+
+@pytest.mark.no_cover
+class TestPortalMarkerRoles:
+    """Portal marker applies roles to the test user."""
+
+    def test_grant_manager_role(self, testdir):
+        testdir.makepyfile(
+            """
+            import pytest
+            from plone import api
+            from plone.app.testing import TEST_USER_ID
+
+            @pytest.mark.portal(roles=["Manager"])
+            def test_user_has_manager_role(portal):
+                roles = api.user.get_roles(username=TEST_USER_ID, obj=portal)
+                assert "Manager" in roles
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=1)
+
+    def test_grant_multiple_roles(self, testdir):
+        testdir.makepyfile(
+            """
+            import pytest
+            from plone import api
+            from plone.app.testing import TEST_USER_ID
+
+            @pytest.mark.portal(roles=["Manager", "Reviewer"])
+            def test_user_has_multiple_roles(portal):
+                roles = api.user.get_roles(username=TEST_USER_ID, obj=portal)
+                assert "Manager" in roles
+                assert "Reviewer" in roles
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=1)
+
+
+@pytest.mark.no_cover
+class TestPortalMarkerContent:
+    """Portal marker creates content in the portal."""
+
+    def test_create_document(self, testdir):
+        testdir.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.portal(
+                content=[{"type": "Document", "id": "doc1", "title": "A Document"}],
+            )
+            def test_document_exists(portal):
+                assert "doc1" in portal
+                assert portal["doc1"].title == "A Document"
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=1)
+
+    def test_create_multiple_content(self, testdir):
+        testdir.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.portal(
+                content=[
+                    {"type": "Document", "id": "doc1", "title": "Doc 1"},
+                    {"type": "Document", "id": "doc2", "title": "Doc 2"},
+                ],
+            )
+            def test_multiple_content(portal):
+                assert "doc1" in portal
+                assert "doc2" in portal
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=1)
+
+
+@pytest.mark.no_cover
+class TestPortalMarkerProfiles:
+    """Portal marker applies GenericSetup profiles."""
+
+    def test_apply_profile(self, testdir):
+        testdir.makepyfile(
+            """
+            import pytest
+            from plone import api
+
+            @pytest.mark.portal(profiles=["plone.app.contenttypes:default"])
+            def test_profile_applied(portal):
+                setup_tool = api.portal.get_tool("portal_setup")
+                # Verify the profile was applied by checking the profile version
+                version = setup_tool.getLastVersionForProfile(
+                    "plone.app.contenttypes:default"
+                )
+                assert version is not None
+                assert version != "unknown"
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=1)
+
+
+@pytest.mark.no_cover
+class TestPortalMarkerCombined:
+    """Portal marker supports combining profiles, content, and roles."""
+
+    def test_profiles_content_and_roles(self, testdir):
+        testdir.makepyfile(
+            """
+            import pytest
+            from plone import api
+            from plone.app.testing import TEST_USER_ID
+
+            @pytest.mark.portal(
+                content=[{"type": "Document", "id": "doc1", "title": "Doc"}],
+                roles=["Manager"],
+            )
+            def test_combined(portal):
+                assert "doc1" in portal
+                roles = api.user.get_roles(username=TEST_USER_ID, obj=portal)
+                assert "Manager" in roles
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=1)
+
+
+@pytest.mark.no_cover
+class TestPortalMarkerIsolation:
+    """Marker setup doesn't leak between tests (integration layer rollback)."""
+
+    def test_isolation_between_tests(self, testdir):
+        testdir.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.portal(
+                content=[{"type": "Document", "id": "doc1", "title": "Doc"}],
+            )
+            def test_first(portal):
+                assert "doc1" in portal
+
+            def test_second(portal):
+                assert "doc1" not in portal
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=2)


### PR DESCRIPTION
## Summary

- Add `@pytest.mark.portal` marker that lets tests declare GenericSetup profiles, content, and roles inline — without overriding the `portal` fixture
- Add `apply_profiles` session-scoped fixture to apply GenericSetup profiles
- Add `create_content` session-scoped fixture to create content items as the site owner
- Add `grant_roles` session-scoped fixture to grant local roles to the test user
- Document all new fixtures and the marker in README.md

Closes #37

## Example

```python
@pytest.mark.portal(
    profiles=["my.addon:testing"],
    content=[{"type": "Document", "id": "doc1", "title": "Doc 1"}],
    roles=["Manager"],
)
def test_something(portal):
    assert "doc1" in portal
```

## Housekeeping

- Bump Plone version to 6.1.4
- Add `plone-stubs` to test dependencies
- Update VS Code settings (remove obsolete flake8 config, add plone-stubs paths)

## Test plan

- [x] Existing tests without the marker pass unchanged (backwards-compatible)
- [x] Tests with `roles` parameter grant roles to the test user
- [x] Tests with `content` parameter create content in the portal
- [x] Tests with `profiles` parameter apply GenericSetup profiles
- [x] Combined marker parameters work together
- [x] Marker setup doesn't leak between tests (integration layer rollback)