### PR TITLE
Update repository URL to plone/pytest-plone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,10 @@
 
 ### New features:
 
-- Added `@pytest.mark.portal` marker support for configuring the `portal` fixture with GenericSetup profiles, pre-created content, and user roles. @ericof [#37](https://github.com/collective/pytest-plone/issues/37)
-- Added the `uninstalled` fixture — reads a user-provided `package_name` fixture and calls `installer.uninstall_product`, removing boilerplate from the canonical add-on uninstall smoke test. @ericof [#38](https://github.com/collective/pytest-plone/issues/38)
-- Added `functional_app`, `functional_portal`, and `functional_http_request` fixtures — functional-layer counterparts to `app`, `portal`, and `http_request`. `functional_portal` honors the `@pytest.mark.portal` marker. @ericof [#39](https://github.com/collective/pytest-plone/issues/39)
-- Added `request_factory`, `manager_request`, and `anon_request` fixtures — build a `RelativeSession` against the functional portal with Manager, Anonymous, or custom basic-auth credentials. Replaces boilerplate duplicated across downstream codebases. @ericof [#40](https://github.com/collective/pytest-plone/issues/40)
+- Added `@pytest.mark.portal` marker support for configuring the `portal` fixture with GenericSetup profiles, pre-created content, and user roles. @ericof [#37](https://github.com/plone/pytest-plone/issues/37)
+- Added the `uninstalled` fixture — reads a user-provided `package_name` fixture and calls `installer.uninstall_product`, removing boilerplate from the canonical add-on uninstall smoke test. @ericof [#38](https://github.com/plone/pytest-plone/issues/38)
+- Added `functional_app`, `functional_portal`, and `functional_http_request` fixtures — functional-layer counterparts to `app`, `portal`, and `http_request`. `functional_portal` honors the `@pytest.mark.portal` marker. @ericof [#39](https://github.com/plone/pytest-plone/issues/39)
+- Added `request_factory`, `manager_request`, and `anon_request` fixtures — build a `RelativeSession` against the functional portal with Manager, Anonymous, or custom basic-auth credentials. Replaces boilerplate duplicated across downstream codebases. @ericof [#40](https://github.com/plone/pytest-plone/issues/40)
 - Added `apply_profiles` session-scoped fixture to apply GenericSetup profiles to a Plone site. @ericof 
 - Added `create_content` session-scoped fixture to create content items in a Plone site as the site owner. @ericof 
 - Added `grant_roles` session-scoped fixture to grant local roles to the test user on a given context. @ericof 
@@ -34,39 +34,39 @@
 
 ### Internal:
 
-- Upgrade zope.pytest to version 8.3. @ericof [#35](https://github.com/collective/pytest-plone/issues/35)
+- Upgrade zope.pytest to version 8.3. @ericof [#35](https://github.com/plone/pytest-plone/issues/35)
 - Fix Makefile release target @ericof 
 - Upgrade pytest to version 8.4.0. @ericof 
 
 
 ### Documentation:
 
-- Fix Tests badge on `README.md`. @stevepiercy [#31](https://github.com/collective/pytest-plone/issues/31)
+- Fix Tests badge on `README.md`. @stevepiercy [#31](https://github.com/plone/pytest-plone/issues/31)
 
 ## 1.0.0a1 (2025-03-27)
 
 
 ### Breaking changes:
 
-- Drop support for Python 3.8 @ericof [#17](https://github.com/collective/pytest-plone/issues/17)
-- Drop support for Python 3.9 @ericof [#18](https://github.com/collective/pytest-plone/issues/18)
+- Drop support for Python 3.8 @ericof [#17](https://github.com/plone/pytest-plone/issues/17)
+- Drop support for Python 3.9 @ericof [#18](https://github.com/plone/pytest-plone/issues/18)
 
 
 ### New features:
 
-- Add support for Python 3.13 @ericof [#19](https://github.com/collective/pytest-plone/issues/19)
-- Add support for Plone 6.1 @ericof [#20](https://github.com/collective/pytest-plone/issues/20)
-- Add docstring for every fixture provided by pytest-plone @ericof [#24](https://github.com/collective/pytest-plone/issues/24)
+- Add support for Python 3.13 @ericof [#19](https://github.com/plone/pytest-plone/issues/19)
+- Add support for Plone 6.1 @ericof [#20](https://github.com/plone/pytest-plone/issues/20)
+- Add docstring for every fixture provided by pytest-plone @ericof [#24](https://github.com/plone/pytest-plone/issues/24)
 
 
 ### Internal:
 
-- Move from `setuptools` to `hatchling` for package build. @ericof [#21](https://github.com/collective/pytest-plone/issues/21)
-- Package metadata now lives in `pyproject.toml`. @ericof [#22](https://github.com/collective/pytest-plone/issues/22)
-- Use UV to manage the development environment. @ericof [#23](https://github.com/collective/pytest-plone/issues/23)
-- Add default `.vscode` configuration @ericof [#25](https://github.com/collective/pytest-plone/issues/25)
-- Add type hints and check codebase with `mypy` [#27](https://github.com/collective/pytest-plone/issues/27)
-- Don't reformat `.md` files. @stevepiercy [#28](https://github.com/collective/pytest-plone/issues/28)
+- Move from `setuptools` to `hatchling` for package build. @ericof [#21](https://github.com/plone/pytest-plone/issues/21)
+- Package metadata now lives in `pyproject.toml`. @ericof [#22](https://github.com/plone/pytest-plone/issues/22)
+- Use UV to manage the development environment. @ericof [#23](https://github.com/plone/pytest-plone/issues/23)
+- Add default `.vscode` configuration @ericof [#25](https://github.com/plone/pytest-plone/issues/25)
+- Add type hints and check codebase with `mypy` [#27](https://github.com/plone/pytest-plone/issues/27)
+- Don't reformat `.md` files. @stevepiercy [#28](https://github.com/plone/pytest-plone/issues/28)
 
 ## 0.5.0 (2024-05-15)
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 
 [![PyPI - Plone Versions](https://img.shields.io/pypi/frameworkversions/plone/pytest-plone)](https://pypi.org/project/pytest-plone/)
 
-[![Tests](https://github.com/collective/pytest-plone/actions/workflows/ci.yml/badge.svg)](https://github.com/collective/pytest-plone/actions/workflows/ci.yml)
+[![Tests](https://github.com/plone/pytest-plone/actions/workflows/ci.yml/badge.svg)](https://github.com/plone/pytest-plone/actions/workflows/ci.yml)
 ![Code Style](https://img.shields.io/badge/Code%20Style-Black-000000)
 
-[![GitHub contributors](https://img.shields.io/github/contributors/collective/pytest-plone)](https://github.com/collective/pytest-plone)
-[![GitHub Repo stars](https://img.shields.io/github/stars/collective/pytest-plone?style=social)](https://github.com/collective/pytest-plone)
+[![GitHub contributors](https://img.shields.io/github/contributors/plone/pytest-plone)](https://github.com/plone/pytest-plone)
+[![GitHub Repo stars](https://img.shields.io/github/stars/plone/pytest-plone?style=social)](https://github.com/plone/pytest-plone)
 </div>
 
 **pytest-plone** is a [pytest](https://docs.pytest.org) plugin providing fixtures and helpers to test [Plone](https://plone.org) add-ons.

--- a/news/+repo-move.internal.md
+++ b/news/+repo-move.internal.md
@@ -1,0 +1,1 @@
+Update repository URL in package metadata and README to https://github.com/plone/pytest-plone — repository moved from the `collective` organization to `plone`. @ericof

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,10 +56,10 @@ test = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/collective/pytest-plone"
+Homepage = "https://github.com/plone/pytest-plone"
 PyPI = "https://pypi.org/project/pytest-plone"
-Source = "https://github.com/collective/pytest-plone"
-Tracker = "https://github.com/collective/pytest-plone/issues"
+Source = "https://github.com/plone/pytest-plone"
+Tracker = "https://github.com/plone/pytest-plone/issues"
 
 
 [project.entry-points.pytest11]
@@ -99,7 +99,7 @@ filename = "CHANGELOG.md"
 start_string = "<!-- towncrier release notes start -->\n"
 title_format = "## {version} ({project_date})"
 template = "news/.changelog_template.jinja"
-issue_format = "[#{issue}](https://github.com/collective/pytest-plone/issues/{issue})"
+issue_format = "[#{issue}](https://github.com/plone/pytest-plone/issues/{issue})"
 underlines = ["", "", ""]
 
 [[tool.towncrier.type]]


### PR DESCRIPTION
## Summary

The repository was moved from the `collective` organization to `plone`. This PR updates every stale URL reference so the canonical location is reflected everywhere (no longer relying on GitHub's auto-redirect from `collective/pytest-plone`).

## Changes

- `pyproject.toml` — `Homepage`, `Source`, `Tracker`, and the towncrier `issue_format` now point at `plone/pytest-plone`.
- `README.md` — CI badge and GitHub contributor/stars badges updated.
- `CHANGELOG.md` — Historical issue links (17 occurrences) updated for canonical URLs.
- `news/+repo-move.internal.md` — Orphan towncrier fragment.

## Test plan

- [x] `grep -rn "collective/pytest-plone"` returns no matches.
- [x] `uvx towncrier build --draft --yes --version 0.0.0` renders the new entry under **Internal**.
- [ ] CI badge renders against the new repo path.