### PR TITLE
Install plone-stubs via Makefile, not [tool.uv.sources]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,10 +67,15 @@ config: instance/etc/zope.ini
 # Install
 ############################################
 
-requirements-mxdev.txt: ## Generate constraints file
+requirements-mxdev.txt: pyproject.toml mx.ini ## Generate constraints file
 	@echo "$(GREEN)==> Generate constraints file$(RESET)"
 	@echo '-c https://dist.plone.org/release/$(PLONE_VERSION)/constraints.txt' > requirements.txt
 	@uvx mxdev -c mx.ini
+	@# plone-stubs is not on PyPI; install from git only on Python >= 3.12.
+	@# The marker has to live here (not in pyproject.toml or mx.ini), since
+	@# uv pip install does not honor [tool.uv.sources] when managed = false,
+	@# and mxdev sections do not support PEP 508 markers per section.
+	@echo "plone-stubs @ git+https://github.com/plone/plone-stubs.git ; python_version >= '3.12'" >> requirements-mxdev.txt
 
 $(VENV_FOLDER): requirements-mxdev.txt ## Install dependencies
 	@echo "$(GREEN)==> Install environment$(RESET)"

--- a/news/45.bugfix.md
+++ b/news/45.bugfix.md
@@ -1,0 +1,1 @@
+Fix CI dependency resolution: `plone-stubs` is now appended to `requirements-mxdev.txt` (with a Python 3.12+ marker) from the Makefile, instead of being declared in `[project.optional-dependencies]` with a `[tool.uv.sources]` git pointer that `uv pip install` ignored. @ericof

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "plone-stubs ; python_version >= '3.12'",
     "pytest-cov",
     "pytest-xdist",
     "mypy>=1.15.0",
@@ -67,9 +66,6 @@ plone = "pytest_plone.fixtures"
 
 [tool.uv]
 managed = false
-
-[tool.uv.sources]
-plone-stubs = { git = "https://github.com/plone/plone-stubs.git" }
 
 [tool.hatch.metadata]
 allow-direct-references = true


### PR DESCRIPTION
Closes #45

## Summary

`uv pip install -r requirements-mxdev.txt` (the install path used by the Makefile when `[tool.uv] managed = false`) does **not** honor `[tool.uv.sources]`. The previous declaration of `plone-stubs` in `[project.optional-dependencies].test` with a git pointer under `[tool.uv.sources]` left CI unable to resolve the dep on every matrix job.

## Approach

Mirror the pattern already in use in [`simplesconsultoria/sc-videos`'s backend Makefile](https://github.com/simplesconsultoria/sc-videos/blob/main/backend/Makefile):

- **`Makefile`** — append the marker'd git URL to `requirements-mxdev.txt` *after* `mxdev` writes the file. Add `pyproject.toml` and `mx.ini` as target dependencies so the file regenerates when either changes.
- **`pyproject.toml`** — drop `plone-stubs` from `[project.optional-dependencies].test` and remove the now-dead `[tool.uv.sources]` section. Keeps the published wheel's `Requires-Dist` PyPI-clean and removes the duplication.
- **`news/45.bugfix.md`** — towncrier fragment.

## Why not inline `pkg @ git+…` in `[project.optional-dependencies]`?

Direct URL references in `Requires-Dist` are rejected by PyPI on upload — would block the next release.

## Test plan

- [x] `make sync` succeeds locally (no resolution error).
- [x] `plone-stubs 0.1.0` installs from the git URL on Python 3.12.
- [x] `make test` — 47 tests pass.
- [x] `make check` — lint + format clean.
- [x] `uvx mypy src` (CI's exact command) — no issues found.
- [ ] CI matrix passes for `{3.10, 3.11, 3.12, 3.13} × {6.0-latest, 6.1-latest}`.