### PR TITLE
Fix mxdev invocation on Python 3.10 (mxdev[uv] extra)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ config: instance/etc/zope.ini
 requirements-mxdev.txt: pyproject.toml mx.ini ## Generate constraints file
 	@echo "$(GREEN)==> Generate constraints file$(RESET)"
 	@echo '-c https://dist.plone.org/release/$(PLONE_VERSION)/constraints.txt' > requirements.txt
-	@uvx mxdev -c mx.ini
+	@uvx --from "mxdev[uv]" mxdev -c mx.ini
 	@# plone-stubs is not on PyPI; install from git only on Python >= 3.12.
 	@# The marker has to live here (not in pyproject.toml or mx.ini), since
 	@# uv pip install does not honor [tool.uv.sources] when managed = false,

--- a/news/+mxdev-uv-hook.internal
+++ b/news/+mxdev-uv-hook.internal
@@ -1,0 +1,1 @@
+Fix `make install` (and CI) on Python 3.10: invoke mxdev with its `uv` extra (`uvx --from "mxdev[uv]" mxdev`) so the `tomlkit` dependency required by mxdev's uv hook is available. @jensens


### PR DESCRIPTION
## Problem

CI's `make install` step fails on **Python 3.10** at the *Generate constraints file* step:

```
ModuleNotFoundError: No module named 'tomlkit'
RuntimeError: tomlkit is required for the uv hook. Install it with: pip install mxdev[uv]
make: *** [Makefile:71: requirements-mxdev.txt] Error 1
```

`uvx mxdev` runs mxdev in an ephemeral environment **without** its `[uv]` extra. A newer mxdev release moved `tomlkit` (needed by the uv hook that writes `requirements-mxdev.txt`/`constraints-mxdev.txt`) into that extra, so the bare invocation now crashes. This is tooling drift — `main` is affected today as well; it merely passed when those jobs last ran.

The Python 3.11–3.14 jobs happen to pass because a cached uv environment still carries `tomlkit`; 3.10 downloads a fresh interpreter and hits the gap.

## Fix

Invoke mxdev with its `uv` extra so `tomlkit` is present:

```make
@uvx --from "mxdev[uv]" mxdev -c mx.ini
```

Verified locally: the constraints/requirements files are generated correctly with this form, whereas the bare `uvx mxdev` crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)