### PR TITLE
Portal marker enhancements, isolation tests, and class-scoped app fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,41 @@ def test_something(portal):
 
 Tests without the marker see no behavior change — fully backwards-compatible.
 
+#### Content specifications
+
+Each dict in `content` is passed as keyword arguments to `plone.api.content.create`. Two keys receive special handling and are consumed before the call:
+
+| Key | Description |
+| --- | --- |
+| `_container` | Path to the container the item is created in, relative to the site root (e.g. `"/folder"`). Defaults to the portal when absent. |
+| `_review_state` | Target workflow state; the item is transitioned there after creation via `plone.api.content.transition`. |
+
+Items are created in list order, so a container listed earlier can be referenced by a later item's `_container`:
+
+```python
+import pytest
+
+
+@pytest.mark.portal(
+    content=[
+        {"type": "Folder", "id": "folder", "title": "Folder"},
+        {
+            "type": "Document",
+            "id": "doc1",
+            "title": "Nested & published",
+            "_container": "/folder",
+            "_review_state": "published",
+        },
+    ],
+)
+def test_nested_content(portal):
+    """The document lives in the folder and is published."""
+    from plone import api
+
+    doc = portal["folder"]["doc1"]
+    assert api.content.get_state(obj=doc) == "published"
+```
+
 ## Plugin Development
 
 You need a working `python` environment (system, virtualenv, pyenv, etc) version 3.8 or superior.

--- a/README.md
+++ b/README.md
@@ -165,6 +165,22 @@ class TestDocument:
         assert portal_class["doc1"].title == "Doc"
 ```
 
+### app_class
+
+|  |  |
+| --- | --- |
+| Description | Zope root shared across every test method in a class. |
+| Required Fixture | **integration_class** |
+| Scope | **Class** |
+
+Class-scoped counterpart to `app`. Shares the single per-class setup/teardown of `portal_class` (the app is the portal's container), so a class can request both `app_class` and `portal_class` without setting the layer up twice.
+
+```python
+class TestApp:
+    def test_app_root(self, app_class):
+        assert app_class.getPhysicalPath() == ("",)
+```
+
 ### http_request
 
 |  |  |
@@ -237,6 +253,22 @@ import pytest
 class TestRESTService:
     def test_portal_available(self, functional_portal_class):
         assert functional_portal_class.title == "Plone site"
+```
+
+### functional_app_class
+
+|  |  |
+| --- | --- |
+| Description | Zope root on the **functional** testing layer, shared across every test method in a class. |
+| Required Fixture | **functional_class** |
+| Scope | **Class** |
+
+Class-scoped counterpart to `functional_app`. Shares the single per-class setup/teardown of `functional_portal_class`, so a class can request both without setting the layer up twice.
+
+```python
+class TestFunctionalApp:
+    def test_app_root(self, functional_app_class):
+        assert functional_app_class.getPhysicalPath() == ("",)
 ```
 
 ### functional_http_request

--- a/news/+trove-classifier-stable.internal
+++ b/news/+trove-classifier-stable.internal
@@ -1,0 +1,1 @@
+Updated the ``Development Status`` trove classifier to ``5 - Production/Stable``. @ericof

--- a/news/52.tests
+++ b/news/52.tests
@@ -1,0 +1,1 @@
+Added regression tests proving ``@pytest.mark.portal`` changes (content, roles, profiles) are undone after each test by the testing layer — including committed functional-layer content served over real HTTP, which ``FunctionalTesting`` discards per test. @ericof

--- a/news/53.feature
+++ b/news/53.feature
@@ -1,0 +1,1 @@
+Added support for creating content in a distinct container (``_container``) and transitioning it to a workflow state (``_review_state``) via the ``@pytest.mark.portal`` marker. @ericof

--- a/news/57.feature
+++ b/news/57.feature
@@ -1,0 +1,1 @@
+Added class-scoped ``app_class`` and ``functional_app_class`` fixtures returning the Zope app root, so accessing the app at class scope no longer requires going through ``portal_class`` and ``aq_parent``. @ericof

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ keywords = [
     "Testing",
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Framework :: Plone",
     "Framework :: Plone :: 6.0",
     "Framework :: Plone :: 6.1",

--- a/src/pytest_plone/fixtures/__init__.py
+++ b/src/pytest_plone/fixtures/__init__.py
@@ -8,7 +8,9 @@ from .addons import profile_last_version
 from .addons import setup_tool
 from .addons import uninstalled
 from .base import app
+from .base import app_class
 from .base import functional_app
+from .base import functional_app_class
 from .base import functional_http_request
 from .base import functional_portal
 from .base import functional_portal_class
@@ -31,11 +33,13 @@ import pytest
 __all__ = [
     "anon_request",
     "app",
+    "app_class",
     "apply_profiles",
     "browser_layers",
     "controlpanel_actions",
     "create_content",
     "functional_app",
+    "functional_app_class",
     "functional_http_request",
     "functional_portal",
     "functional_portal_class",

--- a/src/pytest_plone/fixtures/base.py
+++ b/src/pytest_plone/fixtures/base.py
@@ -50,14 +50,43 @@ def portal(integration: Layer, request: pytest.FixtureRequest) -> PloneSite:
 
 
 @pytest.fixture(scope="class")
+def app_class(
+    integration_class: Layer,
+) -> Generator[Application, None, None]:
+    """Returns the root of a Zope application for an integration Layer, class-scoped.
+
+    Class-scoped counterpart to :func:`app`. ``zope.pytestlayer`` only invokes
+    ``testSetUp`` for function-scoped fixtures, so this fixture drives the
+    per-class ``testSetUp``/``testTearDown`` lifecycle itself. :func:`portal_class`
+    builds on it, so a test class can request both ``app_class`` and
+    ``portal_class`` without setting the layer up twice.
+
+    Example usage:
+    ```python
+    class TestApp:
+        def test_app(self, app_class):
+            assert app_class.title == "Zope"
+    ```
+    """
+    integration_class.testSetUp()
+    try:
+        yield integration_class["app"]
+    finally:
+        integration_class.testTearDown()
+
+
+@pytest.fixture(scope="class")
 def portal_class(
-    integration_class: Layer, request: pytest.FixtureRequest
-) -> Generator[PloneSite, None, None]:
+    app_class: Application,
+    integration_class: Layer,
+    request: pytest.FixtureRequest,
+) -> PloneSite:
     """Returns the default Plone Site for an integration Layer, class-scoped.
 
     Class-scoped counterpart to :func:`portal`. The same portal instance is
     shared across every test method in the class, so setup runs once per class
-    instead of once per test.
+    instead of once per test. The per-class ``testSetUp``/``testTearDown``
+    lifecycle is driven by :func:`app_class`, on which this fixture depends.
 
     Honors ``@pytest.mark.portal`` **applied at the class level** — method-level
     markers are not visible to a class-scoped fixture and are ignored.
@@ -76,17 +105,9 @@ def portal_class(
             assert "doc1" in portal_class
     ```
     """
-    # ``zope.pytestlayer`` only invokes ``testSetUp`` for function-scoped
-    # fixtures, so the layer's ``portal`` key is unset at class scope. Drive
-    # the per-test lifecycle ourselves so the same portal/transaction spans
-    # every test method in the class.
-    integration_class.testSetUp()
-    try:
-        portal: PloneSite = integration_class["portal"]
-        apply_portal_marker(portal, request)
-        yield portal
-    finally:
-        integration_class.testTearDown()
+    portal: PloneSite = integration_class["portal"]
+    apply_portal_marker(portal, request)
+    return portal
 
 
 @pytest.fixture
@@ -139,14 +160,44 @@ def functional_portal(functional: Layer, request: pytest.FixtureRequest) -> Plon
 
 
 @pytest.fixture(scope="class")
+def functional_app_class(
+    functional_class: Layer,
+) -> Generator[Application, None, None]:
+    """Returns the root of a Zope application for a functional Layer, class-scoped.
+
+    Class-scoped counterpart to :func:`functional_app`. ``zope.pytestlayer`` only
+    invokes ``testSetUp`` for function-scoped fixtures, so this fixture drives the
+    per-class ``testSetUp``/``testTearDown`` lifecycle itself.
+    :func:`functional_portal_class` builds on it, so a test class can request both
+    without setting the layer up twice.
+
+    Example usage:
+    ```python
+    class TestFunctionalApp:
+        def test_app(self, functional_app_class):
+            assert functional_app_class.title == "Zope"
+    ```
+    """
+    functional_class.testSetUp()
+    try:
+        yield functional_class["app"]
+    finally:
+        functional_class.testTearDown()
+
+
+@pytest.fixture(scope="class")
 def functional_portal_class(
-    functional_class: Layer, request: pytest.FixtureRequest
-) -> Generator[PloneSite, None, None]:
+    functional_app_class: Application,
+    functional_class: Layer,
+    request: pytest.FixtureRequest,
+) -> PloneSite:
     """Returns the default Plone Site for a functional Layer, class-scoped.
 
     Class-scoped counterpart to :func:`functional_portal`. The same portal
     instance is shared across every test method in the class — the typical
     pattern for REST API / service test suites that need a persistent portal.
+    The per-class ``testSetUp``/``testTearDown`` lifecycle is driven by
+    :func:`functional_app_class`, on which this fixture depends.
 
     Honors ``@pytest.mark.portal`` **applied at the class level** — method-level
     markers are not visible to a class-scoped fixture and are ignored.
@@ -162,13 +213,9 @@ def functional_portal_class(
             ...
     ```
     """
-    functional_class.testSetUp()
-    try:
-        portal: PloneSite = functional_class["portal"]
-        apply_portal_marker(portal, request)
-        yield portal
-    finally:
-        functional_class.testTearDown()
+    portal: PloneSite = functional_class["portal"]
+    apply_portal_marker(portal, request)
+    return portal
 
 
 @pytest.fixture

--- a/src/pytest_plone/fixtures/markers.py
+++ b/src/pytest_plone/fixtures/markers.py
@@ -28,14 +28,44 @@ def apply_profiles(portal: PloneSite, profiles: list[str]) -> None:
             setup_tool.runAllImportStepsFromProfile(profile_id)
 
 
-def create_content(container: PortalContent, content: list[dict]) -> None:
-    """Create content items in a container.
+def create_content(portal: PortalContent, content: list[dict]) -> list[PortalContent]:
+    """Create content items, optionally in a distinct container and review state.
 
-    Each dict in *content* is passed as keyword arguments to
-    ``plone.api.content.create(container=container, **spec)``.
+    Each entry in *content* is a mapping passed as keyword arguments to
+    :func:`plone.api.content.create`. Two keys receive special handling and
+    are consumed before the call:
+
+    - ``_container``: path to the container the item is created in, relative to
+      the site root as understood by :func:`plone.api.content.get`
+      (e.g. ``"/folder"``). Defaults to *portal* when absent.
+    - ``_review_state``: target workflow state; the created item is transitioned
+      to it via :func:`plone.api.content.transition`.
+
+    :param portal: default container used when a spec omits ``_container``.
+    :param content: list of content specifications.
+    :returns: the created content items, in creation order.
     """
+    items = []
     for spec in content:
-        api.content.create(container=container, **spec)
+        # Copy so the special keys we pop below don't mutate the marker's
+        # dicts, which are reused across parametrized runs of the same test.
+        spec = dict(spec)
+        container = portal
+        # Get the container for the content item.
+        if container_path := spec.pop("_container", None):
+            container = api.content.get(path=container_path)
+        # If a review state is specified, we transition the content to
+        # that state after creation.
+        to_state = spec.pop("_review_state", None)
+        item = api.content.create(container=container, **spec)
+        if to_state is not None:
+            api.content.transition(obj=item, to_state=to_state)
+        items.append(item)
+    # Force a reindex: content created here has been observed to stay stale in
+    # the catalog (not returned by queries) until reindexed explicitly.
+    for item in items:
+        item.reindexObject()
+    return items
 
 
 def grant_roles(context: PortalContent, roles: list[str]) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,11 +61,13 @@ def testdir_no_keep(pytester: Pytester) -> Pytester:
 OUR_FIXTURES = [
     "anon_request",
     "app",
+    "app_class",
     "apply_profiles",
     "browser_layers",
     "controlpanel_actions",
     "create_content",
     "functional_app",
+    "functional_app_class",
     "functional_http_request",
     "functional_portal",
     "functional_portal_class",

--- a/tests/fixtures/test_class_scoped.py
+++ b/tests/fixtures/test_class_scoped.py
@@ -88,6 +88,36 @@ class TestPortalClassMarker:
 
 
 @pytest.mark.no_cover
+class TestAppClass:
+    """``app_class`` is the class-scoped Zope app root."""
+
+    def test_app_class_returns_app(self, testdir):
+        testdir.makepyfile(
+            """
+            class TestAppClassBasic:
+                def test_app_title(self, app_class):
+                    assert app_class.title == "Zope"
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=1)
+
+    def test_app_class_and_portal_class_share_lifecycle(self, testdir):
+        """Requesting both must not set the layer up twice."""
+        testdir.makepyfile(
+            """
+            from Acquisition import aq_base
+
+            class TestAppAndPortal:
+                def test_app_is_portal_parent(self, app_class, portal_class):
+                    assert aq_base(app_class) is aq_base(portal_class.aq_parent)
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=1)
+
+
+@pytest.mark.no_cover
 class TestFunctionalPortalClass:
     """``functional_portal_class`` is class-scoped on the functional layer."""
 
@@ -116,6 +146,22 @@ class TestFunctionalPortalClass:
                         username=TEST_USER_ID, obj=functional_portal_class
                     )
                     assert "Manager" in roles
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=1)
+
+
+@pytest.mark.no_cover
+class TestFunctionalAppClass:
+    """``functional_app_class`` is the class-scoped Zope app root."""
+
+    def test_functional_app_class_returns_app(self, testdir):
+        testdir.makepyfile(
+            """
+            class TestFunctionalAppClassBasic:
+                def test_app_title(self, functional_app_class):
+                    assert functional_app_class.title == "Zope"
             """
         )
         result = testdir.runpytest_subprocess()

--- a/tests/fixtures/test_functional_commit_isolation.py
+++ b/tests/fixtures/test_functional_commit_isolation.py
@@ -1,0 +1,71 @@
+"""Committed functional-layer changes are isolated per test.
+
+The ``portal`` marker (and any test that stages content) relies on the testing
+layer to undo its changes after each test.  For plain integration/ORM tests
+that is the per-test ``transaction.abort()``.  The harder case is a *functional*
+test that **commits** — needed so a real HTTP request, served on a separate
+thread and ZODB connection, can see the content.  This module proves that even
+in that case ``FunctionalTesting`` discards the committed data at teardown (via
+its stacked ``DemoStorage``), so nothing leaks into the next test.
+
+A committing marker would therefore need no explicit teardown: the layer already
+undoes the change.  These tests lock that guarantee in.
+"""
+
+import pytest
+
+
+# A functional layer with a real WSGI server so ``absolute_url()`` is reachable
+# over HTTP.  ``PLONE_FIXTURE`` keeps it lightweight; we only need traversal.
+SERVER_CONFTEST = """
+    from plone.app.testing import FunctionalTesting
+    from plone.app.testing import PLONE_FIXTURE
+    from plone.testing.zope import WSGI_SERVER_FIXTURE
+    from pytest_plone import fixtures_factory
+
+    pytest_plugins = ["pytest_plone"]
+
+    SERVER_FUNCTIONAL = FunctionalTesting(
+        bases=(PLONE_FIXTURE, WSGI_SERVER_FIXTURE),
+        name="pytest_plone:ServerFunctional",
+    )
+
+    globals().update(fixtures_factory(((SERVER_FUNCTIONAL, "functional"),)))
+"""
+
+COMMIT_AND_FETCH = """
+    import requests
+    import transaction
+    from plone import api
+    from plone.app.testing import SITE_OWNER_NAME, SITE_OWNER_PASSWORD
+
+    def _get(portal, path):
+        return requests.get(
+            f"{portal.absolute_url()}/{path}",
+            auth=(SITE_OWNER_NAME, SITE_OWNER_PASSWORD),
+        )
+
+    def test_first_commits_and_serves(functional_portal):
+        portal = functional_portal
+        with api.env.adopt_user(SITE_OWNER_NAME):
+            api.content.create(
+                container=portal, type="Document", id="doc1", title="D"
+            )
+        transaction.commit()
+        # The real HTTP server (separate connection) sees the committed content.
+        assert _get(portal, "doc1").status_code == 200
+
+    def test_second_does_not_see_it(functional_portal):
+        portal = functional_portal
+        # Committed data from the previous test was discarded at teardown.
+        assert "doc1" not in portal
+        assert _get(portal, "doc1").status_code == 404
+"""
+
+
+@pytest.mark.no_cover
+def test_committed_functional_change_is_isolated(testdir):
+    testdir.makeconftest(SERVER_CONFTEST)
+    testdir.makepyfile(COMMIT_AND_FETCH)
+    result = testdir.runpytest_subprocess()
+    result.assert_outcomes(passed=2)

--- a/tests/fixtures/test_functional_layer.py
+++ b/tests/fixtures/test_functional_layer.py
@@ -85,3 +85,52 @@ class TestFunctionalPortalMarker:
         )
         result = testdir.runpytest_subprocess()
         result.assert_outcomes(passed=1)
+
+
+@pytest.mark.no_cover
+class TestFunctionalPortalMarkerIsolation:
+    """Marker changes don't leak between functional-layer tests."""
+
+    def test_content_does_not_leak(self, testdir):
+        testdir.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.portal(
+                content=[{"type": "Document", "id": "doc1", "title": "Doc"}],
+            )
+            def test_first(functional_portal):
+                assert "doc1" in functional_portal
+
+            def test_second(functional_portal):
+                assert "doc1" not in functional_portal
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=2)
+
+    def test_roles_do_not_leak(self, testdir):
+        # "Reviewer" (not the baseline "Manager") so presence in the second test
+        # is a real leak — see the equivalent integration test for the rationale.
+        testdir.makepyfile(
+            """
+            import pytest
+            from plone import api
+            from plone.app.testing import TEST_USER_ID
+
+            @pytest.mark.portal(roles=["Reviewer"])
+            def test_first(functional_portal):
+                roles = api.user.get_roles(
+                    username=TEST_USER_ID, obj=functional_portal
+                )
+                assert "Reviewer" in roles
+
+            def test_second(functional_portal):
+                roles = api.user.get_roles(
+                    username=TEST_USER_ID, obj=functional_portal
+                )
+                assert "Reviewer" not in roles
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=2)

--- a/tests/fixtures/test_marker_portal.py
+++ b/tests/fixtures/test_marker_portal.py
@@ -97,6 +97,115 @@ class TestPortalMarkerContent:
 
 
 @pytest.mark.no_cover
+class TestPortalMarkerContentContainer:
+    """Portal marker creates content in a distinct container via ``_container``."""
+
+    def test_create_in_container(self, testdir):
+        testdir.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.portal(
+                content=[
+                    {"type": "Folder", "id": "folder", "title": "Folder"},
+                    {
+                        "type": "Document",
+                        "id": "doc1",
+                        "title": "Nested",
+                        "_container": "/folder",
+                    },
+                ],
+            )
+            def test_document_in_folder(portal):
+                assert "folder" in portal
+                assert "doc1" not in portal
+                assert "doc1" in portal["folder"]
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=1)
+
+
+@pytest.mark.no_cover
+class TestPortalMarkerContentReviewState:
+    """Portal marker transitions content via ``_review_state``."""
+
+    def test_create_in_review_state(self, testdir):
+        testdir.makepyfile(
+            """
+            import pytest
+            from plone import api
+
+            @pytest.mark.portal(
+                content=[
+                    {
+                        "type": "Document",
+                        "id": "doc1",
+                        "title": "Published",
+                        "_review_state": "published",
+                    },
+                ],
+            )
+            def test_document_published(portal):
+                assert api.content.get_state(obj=portal["doc1"]) == "published"
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=1)
+
+    def test_content_is_catalogued(self, testdir):
+        testdir.makepyfile(
+            """
+            import pytest
+            from plone import api
+
+            @pytest.mark.portal(
+                content=[
+                    {
+                        "type": "Document",
+                        "id": "doc1",
+                        "title": "Published",
+                        "_review_state": "published",
+                    },
+                ],
+            )
+            def test_document_found_in_catalog(portal):
+                results = api.content.find(review_state="published", id="doc1")
+                assert len(results) == 1
+                assert results[0].getPath().endswith("/doc1")
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=1)
+
+    def test_container_and_review_state_combined(self, testdir):
+        testdir.makepyfile(
+            """
+            import pytest
+            from plone import api
+
+            @pytest.mark.portal(
+                content=[
+                    {"type": "Folder", "id": "folder", "title": "Folder"},
+                    {
+                        "type": "Document",
+                        "id": "doc1",
+                        "title": "Nested Published",
+                        "_container": "/folder",
+                        "_review_state": "published",
+                    },
+                ],
+            )
+            def test_nested_published(portal):
+                doc = portal["folder"]["doc1"]
+                assert api.content.get_state(obj=doc) == "published"
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=1)
+
+
+@pytest.mark.no_cover
 class TestPortalMarkerProfiles:
     """Portal marker applies GenericSetup profiles."""
 

--- a/tests/fixtures/test_marker_portal.py
+++ b/tests/fixtures/test_marker_portal.py
@@ -276,3 +276,49 @@ class TestPortalMarkerIsolation:
         )
         result = testdir.runpytest_subprocess()
         result.assert_outcomes(passed=2)
+
+    def test_roles_do_not_leak(self, testdir):
+        # Use "Reviewer", NOT "Manager": the Products.CMFPlone test layer grants
+        # the test user "Manager" *globally* by default, so a Manager-based probe
+        # would see it in the second test regardless of the marker and wrongly
+        # look like a leak. "Reviewer" is not a baseline role, so its presence in
+        # the second test would be a genuine leak from the first.
+        testdir.makepyfile(
+            """
+            import pytest
+            from plone import api
+            from plone.app.testing import TEST_USER_ID
+
+            @pytest.mark.portal(roles=["Reviewer"])
+            def test_first(portal):
+                roles = api.user.get_roles(username=TEST_USER_ID, obj=portal)
+                assert "Reviewer" in roles
+
+            def test_second(portal):
+                roles = api.user.get_roles(username=TEST_USER_ID, obj=portal)
+                assert "Reviewer" not in roles
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=2)
+
+    def test_profiles_do_not_leak(self, testdir):
+        testdir.makepyfile(
+            """
+            import pytest
+            from plone import api
+
+            PROFILE = "plone.session:default"
+
+            @pytest.mark.portal(profiles=[PROFILE])
+            def test_first(portal):
+                st = api.portal.get_tool("portal_setup")
+                assert st.getLastVersionForProfile(PROFILE) != "unknown"
+
+            def test_second(portal):
+                st = api.portal.get_tool("portal_setup")
+                assert st.getLastVersionForProfile(PROFILE) == "unknown"
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=2)


### PR DESCRIPTION
## What

Three related improvements to the `@pytest.mark.portal` marker and the class-scoped fixtures, plus a packaging bump.

### #53 — Container + workflow state in marker content
`@pytest.mark.portal(content=[...])` specs now accept two special keys:

- `_container` — path (relative to the site root) of the container to create the item in; defaults to the portal.
- `_review_state` — target workflow state; the item is transitioned there after creation.

Specs are copied before these keys are consumed, so the marker's dicts survive parametrized reruns, and created items are reindexed to avoid catalog staleness.

### #52 — Marker changes are isolated per test
Investigation confirmed the testing layer already undoes every marker change — `transaction.abort()` for the integration/ORM path, and `DemoStorage` stacking for **committed** functional-layer data served over real HTTP. This adds regression tests that lock the guarantee in (content, roles, profiles; integration + functional; and the committed-over-HTTP case), so a future refactor that broke isolation would fail loudly.

### #57 — Class-scoped `app_class` / `functional_app_class`
New class-scoped fixtures returning the Zope app root, so accessing the app at class scope no longer requires going through `portal_class` and `aq_parent`. Each `app_class` fixture drives the single per-class `testSetUp`/`testTearDown` lifecycle; the matching `portal_class` depends on it, so a class can request both without setting the layer up twice.

### Packaging
Bumped the `Development Status` trove classifier from `3 - Alpha` to `5 - Production/Stable`.

## Testing
- Full suite green (71 passed)
- `uvx mypy src` clean
- `ruff` clean
- News fragments added for each change

Closes #52
Closes #53
Closes #57