### PR TITLE
Add plone.distribution support

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,71 @@ def test_public_endpoint(anon_request):
     assert response.status_code == 200
 ```
 
+### site_owner_name / site_owner_password
+
+|  |  |
+| --- | --- |
+| Description | Login name / password of the site owner (Manager) test user. |
+| Required Fixture |  |
+| Scope | **Session** |
+
+Session-scoped accessors for `SITE_OWNER_NAME` / `SITE_OWNER_PASSWORD` from `plone.app.testing`, so tests and other fixtures can depend on them instead of importing the constants directly.
+
+### create_site
+
+|  |  |
+| --- | --- |
+| Description | Callable that creates a Plone site from a `plone.distribution` distribution. |
+| Required Fixture | **distribution_name**, **site_owner_name** |
+| Scope | **Session** |
+
+Returns a callable `func(app, answers) -> PloneSite`. It deletes any existing site with the same `site_id` first (clean state), creates a **new** site from the `distribution_name` distribution as the site owner, and sets it as the current local site. The created site coexists with the site provided by the testing layer (a second site, by design).
+
+The supporting fixtures are all session-scoped and meant to be **overridden** in your own `conftest.py`:
+
+| Fixture | Description |
+| --- | --- |
+| `distribution_name` | Name of the distribution to create sites from (default `"testing"`). |
+| `answers` | Mapping of answers passed to the distribution handler (site id, title, language, ...). |
+| `site_logo` | Data-URI logo used as the `site_logo` answer. |
+
+The distribution named by `distribution_name` must be registered — e.g. load the ZCML of a package that registers it via `<plone:distribution>`.
+
+Override `distribution_name` and `answers` in your own `conftest.py` to point at your distribution and customize the site:
+
+```python
+import pytest
+
+
+@pytest.fixture(scope="session")
+def distribution_name() -> str:
+    return "my.distribution"
+
+
+@pytest.fixture(scope="session")
+def answers(site_logo: str) -> dict:
+    return {
+        "site_id": "plone-site",
+        "title": "My Site",
+        "description": "A site built from my distribution.",
+        "default_language": "en",
+        "portal_timezone": "UTC",
+        "site_logo": site_logo,
+        "setup_content": False,
+    }
+
+
+class TestDistribution:
+    @pytest.fixture(autouse=True)
+    def _setup(self, app):
+        self.app = app
+
+    def test_site_from_distribution(self, create_site, answers):
+        site = create_site(self.app, answers)
+        assert site.getId() == "plone-site"
+        assert site.title == "My Site"
+```
+
 ## Markers
 
 ### @pytest.mark.portal

--- a/mx.ini
+++ b/mx.ini
@@ -8,6 +8,6 @@
 main-package = -e .[test]
 version-overrides =
     plone.autoinclude>=2.0.3
-    pytest-plone>=1.0.0a1
+    pytest-plone>=1.0.0
     zope.pytestlayer>=8.3
     pytest>=8.4.0

--- a/news/58.feature
+++ b/news/58.feature
@@ -1,0 +1,1 @@
+Added ``plone.distribution`` support: a ``create_site`` fixture that creates a Plone site from a distribution, plus supporting ``distribution_name``, ``answers``, and ``site_logo`` fixtures (all overridable) and ``site_owner_name`` / ``site_owner_password`` fixtures. @ericof

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ dependencies = [
     "plone.browserlayer",
     "plone.dexterity",
     "Products.CMFPlone[test]",
+    "plone.distribution",
+    "plone.exportimport",
     "requests",
     "zope.component",
     "zope.schema",
@@ -53,6 +55,8 @@ test = [
     "towncrier>=23.11.0",
     "zest-releaser[recommended]>=9.1.3",
     "zestreleaser-towncrier>=1.3.0",
+    "plone.app.caching",
+    "plone.volto",
 ]
 
 [project.urls]

--- a/src/pytest_plone/_types.py
+++ b/src/pytest_plone/_types.py
@@ -1,3 +1,4 @@
+from OFS.Application import Application
 from OFS.SimpleItem import Item
 from plone.app.vocabularies import PermissiveVocabulary
 from plone.app.vocabularies import SlicableVocabulary
@@ -56,3 +57,7 @@ class RequestFactory(Protocol):
         basic_auth: tuple[str, str] | None = ...,
         api: bool = ...,
     ) -> Any: ...
+
+
+class SiteCreator(Protocol):
+    def __call__(self, app: Application, answers: dict) -> PloneSite: ...

--- a/src/pytest_plone/fixtures/__init__.py
+++ b/src/pytest_plone/fixtures/__init__.py
@@ -17,9 +17,15 @@ from .base import functional_portal_class
 from .base import http_request
 from .base import portal
 from .base import portal_class
+from .base import site_owner_name
+from .base import site_owner_password
 from .content import create_content
 from .content import get_behaviors
 from .content import get_fti
+from .distribution import answers
+from .distribution import create_site
+from .distribution import distribution_name
+from .distribution import site_logo
 from .env import generate_mo
 from .requests import anon_request
 from .requests import manager_request
@@ -32,12 +38,15 @@ import pytest
 
 __all__ = [
     "anon_request",
+    "answers",
     "app",
     "app_class",
     "apply_profiles",
     "browser_layers",
     "controlpanel_actions",
     "create_content",
+    "create_site",
+    "distribution_name",
     "functional_app",
     "functional_app_class",
     "functional_http_request",
@@ -56,6 +65,9 @@ __all__ = [
     "profile_last_version",
     "request_factory",
     "setup_tool",
+    "site_logo",
+    "site_owner_name",
+    "site_owner_password",
     "uninstalled",
 ]
 

--- a/src/pytest_plone/fixtures/base.py
+++ b/src/pytest_plone/fixtures/base.py
@@ -3,11 +3,31 @@
 from .markers import apply_portal_marker
 from collections.abc import Generator
 from OFS.Application import Application
+from plone.app.testing import SITE_OWNER_NAME
+from plone.app.testing import SITE_OWNER_PASSWORD
 from plone.testing.layer import Layer
 from Products.CMFPlone.Portal import PloneSite
 from ZPublisher.HTTPRequest import HTTPRequest
 
 import pytest
+
+
+@pytest.fixture(scope="session")
+def site_owner_name() -> str:
+    """Return the login name of the site owner (Manager) test user.
+
+    :returns: the ``SITE_OWNER_NAME`` from :mod:`plone.app.testing`.
+    """
+    return SITE_OWNER_NAME
+
+
+@pytest.fixture(scope="session")
+def site_owner_password() -> str:
+    """Return the password of the site owner (Manager) test user.
+
+    :returns: the ``SITE_OWNER_PASSWORD`` from :mod:`plone.app.testing`.
+    """
+    return SITE_OWNER_PASSWORD
 
 
 @pytest.fixture()

--- a/src/pytest_plone/fixtures/distribution.py
+++ b/src/pytest_plone/fixtures/distribution.py
@@ -1,0 +1,86 @@
+from OFS.Application import Application
+from plone import api
+from plone.distribution.api import site as site_api
+from Products.CMFPlone.Portal import PloneSite
+from pytest_plone import _types as t
+from typing import Any
+from zope.component.hooks import setSite
+
+import pytest
+
+
+TEST_LOGO = """filenameb64:dGVzdC1sb2dvLnN2Zw==;datab64:PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2ZXJzaW9uPSIxLjEiIGlkPSJMYXllcl8xIiB4PSIwcHgiIHk9IjBweCIgd2lkdGg9IjE1OC4yNTNweCIgaGVpZ2h0PSI0MC42ODZweCIgdmlld0JveD0iMCAwIDE1OC4yNTMgNDAuNjg2IiBlbmFibGUtYmFja2dyb3VuZD0ibmV3IDAgMCAxNTguMjUzIDQwLjY4NiIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+CiAgPGcgZmlsbD0iIzAyMTMyMiI+CiAgICA8cGF0aCBkPSJNNjUuMzI3LDIzLjIwOGgtNi41ODl2MTEuMzg4aC00LjM5M1Y1LjYzOGgxMC45ODFjNS42NTMsMCw5LjI3MSwzLjc0Miw5LjI3MSw4Ljc4NSAgICAgICAgICAgICAgICAgUzcwLjk3OSwyMy4yMDgsNjUuMzI3LDIzLjIwOHogTTY1LjA4Miw5LjU4M2gtNi4zNDV2OS42MzloNi4zNDVjMy4wNSwwLDUuMTI0LTEuNzQ5LDUuMTI0LTQuNzk5ICAgICAgICAgICAgICAgICBDNzAuMjA2LDExLjM3Miw2OC4xMzIsOS41ODMsNjUuMDgyLDkuNTgzeiIvPgogICAgPHBhdGggZD0iTTgzLjk2OSwzNC41OTZjLTMuOTA0LDAtNS42NTItMi42NDQtNS42NTItNS42OTNWNS42MzhoNC4xNDh2MjMuMDIxYzAsMS41ODcsMC41NjcsMi4zOTksMi4yMzUsMi4zOTloMS44MyAgICAgICAgICAgICAgICAgdjMuNTM4SDgzLjk2OXoiLz4KICAgIDxwYXRoIGQ9Ik0xMDQuNzYyLDMyLjM5OWMtMS4zNDQsMS4zODQtMy4zNzcsMi40NC02LjE4NCwyLjQ0Yy0yLjgwNSwwLTQuNzk5LTEuMDU4LTYuMTQxLTIuNDQgICAgICAgICAgICAgICAgIGMtMS45NTEtMi4wMzItMi40MzktNC42MzctMi40MzktOC4xMzRjMC0zLjQ1NywwLjQ4OC02LjA2MSwyLjQzOS04LjA5NGMxLjM0Mi0xLjM4MywzLjMzNi0yLjQ0LDYuMTQxLTIuNDQgICAgICAgICAgICAgICAgIGMyLjgwNywwLDQuODQsMS4wNTksNi4xODQsMi40NGMxLjk1MSwyLjAzMywyLjQzOSw0LjYzNywyLjQzOSw4LjA5NEMxMDcuMjAzLDI3Ljc2MywxMDYuNzEzLDMwLjM2NiwxMDQuNzYyLDMyLjM5OXogICAgICAgICAgICAgICAgICBNMTAxLjYyOSwxOC42MTNjLTAuNzczLTAuNzczLTEuODMtMS4xODEtMy4wNTEtMS4xODFjLTEuMjE5LDAtMi4yMzYsMC40MDYtMy4wMSwxLjE4MWMtMS4yNiwxLjI2MS0xLjQyMiwzLjQxNi0xLjQyMiw1LjY1MiAgICAgICAgICAgICAgICAgczAuMTYyLDQuMzkzLDEuNDIyLDUuNjUzYzAuNzczLDAuNzcxLDEuNzkxLDEuMjIsMy4wMSwxLjIyYzEuMjIxLDAsMi4yNzctMC40NDcsMy4wNTEtMS4yMmMxLjI2Mi0xLjI2MiwxLjQyNC0zLjQxNywxLjQyNC01LjY1MyAgICAgICAgICAgICAgICAgUzEwMi44OTEsMTkuODczLDEwMS42MjksMTguNjEzeiIvPgogICAgPHBhdGggZD0iTTEyMy42NDMsMzQuNTk2VjIyLjAyOWMwLTMuMjE0LTEuODMtNC41OTctNC4xNDctNC41OTdzLTQuMjcxLDEuNDIzLTQuMjcxLDQuNTk3djEyLjU2NmgtNC4xNDd2LTIwLjYyICAgICAgICAgICAgICAgICBoNC4wNjV2Mi4wNzRjMS40MjUtMS41NDYsMy40MTYtMi4zMTgsNS40OS0yLjMxOGMyLjExNSwwLDMuODY1LDAuNjkxLDUuMDg0LDEuODcxYzEuNTg2LDEuNTQ1LDIuMDc0LDMuNDk3LDIuMDc0LDUuODE1djEzLjE3OCAgICAgICAgICAgICAgICAgTDEyMy42NDMsMzQuNTk2TDEyMy42NDMsMzQuNTk2eiIvPgogICAgPHBhdGggZD0iTTEzNS43NzIsMjUuNDg2YzAsMy41MzcsMS44NzEsNS43NzQsNS4yNDYsNS43NzRjMi4zMTcsMCwzLjUzOS0wLjY0OSw1LjAwNC0yLjExNWwyLjY0MywyLjQ4MSAgICAgICAgICAgICAgICAgYy0yLjExNSwyLjExNC00LjEwNywzLjIxMy03LjcyNywzLjIxM2MtNS4xNjYsMC05LjI3My0yLjcyNS05LjI3My0xMC41NzRjMC02LjY3MSwzLjQ1Ny0xMC41MzQsOC43NDQtMTAuNTM0ICAgICAgICAgICAgICAgICBjNS41MzEsMCw4Ljc0NCw0LjA2Nyw4Ljc0NCw5LjkyNXYxLjgzSDEzNS43NzJ6IE0xNDQuNDc1LDE5Ljc5MWMtMC42NS0xLjU0NS0yLjExMy0yLjYwNC00LjA2Ni0yLjYwNCAgICAgICAgICAgICAgICAgYy0xLjk1MSwwLTMuNDU3LDEuMDU5LTQuMTA3LDIuNjA0Yy0wLjQwNiwwLjkzNi0wLjQ4OCwxLjU0Ni0wLjUyOSwyLjgwN2g5LjI3M0MxNDUuMDAzLDIxLjMzNywxNDQuODgzLDIwLjcyNiwxNDQuNDc1LDE5Ljc5MXoiLz4KICAgIDxjaXJjbGUgY3g9IjE3LjgxNSIgY3k9IjExLjUxNiIgcj0iNC40MDIiLz4KICAgIDxwYXRoIGQ9Ik0zMS4xNjcsMjAuMzExYzAsMi40MzMtMS45NjksNC40MDEtNC40MDMsNC40MDFjLTIuNDI3LDAtNC40MDEtMS45Ny00LjQwMS00LjQwMSAgICAgICAgICAgICAgICAgYzAtMi40MzMsMS45NzUtNC40MDEsNC40MDEtNC40MDFDMjkuMiwxNS45MDksMzEuMTY3LDE3Ljg3OSwzMS4xNjcsMjAuMzExeiIvPgogICAgPGNpcmNsZSBjeD0iMTcuODAxIiBjeT0iMjkuMTMxIiByPSI0LjQwMiIvPgogICAgPGc+CiAgICAgIDxwYXRoIGQ9Ik0yMC40NDEtMC4wNDVDOS4yMDctMC4wNDQsMC4xLDkuMDYzLDAuMDk5LDIwLjI5OEMwLjEsMzEuNTMyLDkuMjA3LDQwLjYzOSwyMC40NDEsNDAuNjQxICAgICAgICAgICAgICAgICAgICAgYzExLjIzNS0wLjAwMiwyMC4zNDEtOS4xMDcsMjAuMzQzLTIwLjM0M0M0MC43ODMsOS4wNjMsMzEuNjc3LTAuMDQ0LDIwLjQ0MS0wLjA0NXogTTMxLjg5MSwzMS43NDcgICAgICAgICAgICAgICAgICAgICBjLTIuOTM3LDIuOTM0LTYuOTcyLDQuNzQyLTExLjQ1LDQuNzQzYy00LjQ3OC0wLjAwMS04LjUxMy0xLjgxMS0xMS40NS00Ljc0M0M2LjA1OCwyOC44MSw0LjI1LDI0Ljc3NSw0LjI0OSwyMC4yOTggICAgICAgICAgICAgICAgICAgICBjMC4wMDEtNC40NzgsMS44MDktOC41MTMsNC43NDMtMTEuNDVjMi45MzctMi45MzQsNi45NzItNC43NDIsMTEuNDUtNC43NDNjNC40NzgsMC4wMDEsOC41MTMsMS44MSwxMS40NSw0Ljc0MyAgICAgICAgICAgICAgICAgICAgIGMyLjkzNCwyLjkzOCw0Ljc0Miw2Ljk3Myw0Ljc0MywxMS40NUMzNi42MzMsMjQuNzc1LDM0LjgyNSwyOC44MSwzMS44OTEsMzEuNzQ3eiIvPgogICAgPC9nPgogICAgPGc+CiAgICAgIDxwYXRoIGQ9Ik0xNTMuOTg1LDkuOTVjLTEuMTk1LDAtMi4xNjQsMC45NzEtMi4xNjQsMi4xNjhjMC4wMDIsMS4xOTcsMC45NjksMi4xNjgsMi4xNjQsMi4xNjggICAgICAgICAgICAgICAgICAgICBjMS4xOTksMCwyLjE3Mi0wLjk3MSwyLjE3Mi0yLjE2OFMxNTUuMTg0LDkuOTUsMTUzLjk4NSw5Ljk1eiBNMTUzLjk4NSwxMy45NjhjLTEuMDIxLTAuMDAyLTEuODQ2LTAuODI3LTEuODQ2LTEuODUgICAgICAgICAgICAgICAgICAgICBjMC4wMDItMS4wMjEsMC44MjUtMS44NDksMS44NDYtMS44NTFjMS4wMjMsMC4wMDIsMS44NTIsMC44MjgsMS44NTQsMS44NTFDMTU1LjgzNiwxMy4xNDEsMTU1LjAwOCwxMy45NjYsMTUzLjk4NSwxMy45Njh6Ii8+CiAgICA8L2c+CiAgICA8Zz4KICAgICAgPHBhdGggZD0iTTE1NC41MDcsMTMuNDA5bC0wLjU0LTEuMDhoLTAuNDg2djEuMDhoLTAuMzg5di0yLjU2NGgwLjk5NGMwLjQ4NCwwLDAuNzk2LDAuMzEzLDAuNzk2LDAuNzUgICAgICAgICAgICAgICAgICAgICBjMCwwLjM2Ny0wLjIyNCwwLjYwMi0wLjUxMywwLjY4bDAuNTkyLDEuMTM2TDE1NC41MDcsMTMuNDA5TDE1NC41MDcsMTMuNDA5eiBNMTU0LjA1NiwxMS4xOTVoLTAuNTc1djAuODAzaDAuNTc1IGMwLjI2MSwwLDAuNDM3LTAuMTQ3LDAuNDM3LTAuMzk5UzE1NC4zMTcsMTEuMTk1LDE1NC4wNTYsMTEuMTk1eiIvPgogICAgPC9nPgogIDwvZz4KPC9zdmc+Cg=="""  # noqa: E501
+
+
+@pytest.fixture(scope="session")
+def site_logo() -> str:
+    """Return a data-URI logo usable as the ``site_logo`` answer.
+
+    :returns: an SVG image encoded as a ``data:`` URI.
+    """
+    return TEST_LOGO
+
+
+@pytest.fixture(scope="session")
+def answers(site_logo: str) -> dict:
+    """Return the default answers for creating a distribution site.
+
+    Override this fixture on your tests to change the answers
+    for creating a Plone site from a distribution.
+
+    :param site_logo: data-URI logo injected as the ``site_logo`` answer.
+    :returns: a mapping of answers passed to the distribution site handler.
+    """
+    return {
+        "site_id": "plone-site",
+        "title": "Plone Site",
+        "description": "New site.",
+        "default_language": "en",
+        "portal_timezone": "UTC",
+        "site_logo": site_logo,
+        "setup_content": False,
+    }
+
+
+@pytest.fixture(scope="session")
+def distribution_name() -> str:
+    """Return the name of the distribution to create sites from.
+
+    Override this fixture on your tests to change the distribution used
+    for creating Plone sites with the fixture `create_site`.
+
+    :returns: the distribution name.
+    """
+    return "testing"
+
+
+@pytest.fixture(scope="session")
+def create_site(distribution_name: str, site_owner_name: str) -> t.SiteCreator:
+    """Return a callable that creates a Plone site from a distribution.
+
+    The returned callable creates a **new** site in *app* from the
+    *distribution_name* distribution, deleting any existing site with the same
+    ``site_id`` first to guarantee a clean state, and sets it as the current
+    local site. The created site coexists with the site provided by the testing
+    layer (a second site, by design).
+
+    :param distribution_name: distribution the site is created from.
+    :param site_owner_name: login of the site owner the site is created as.
+    :returns: a callable ``func(app, answers) -> PloneSite``.
+    """
+
+    def func(app: Application, answers: dict[str, Any]) -> PloneSite:
+        with api.env.adopt_user(site_owner_name):
+            # Delete site if it already exists to ensure a clean state
+            if (site_id := answers.get("site_id")) and site_id in app.objectIds():
+                app.manage_delObjects([site_id])
+            # Use _create_site to avoid committing the changes
+            site = site_api._create_site(
+                context=app,
+                distribution_name=distribution_name,
+                answers=answers,
+            )
+            setSite(site)
+        return site
+
+    return func

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,12 +60,15 @@ def testdir_no_keep(pytester: Pytester) -> Pytester:
 
 OUR_FIXTURES = [
     "anon_request",
+    "answers",
     "app",
     "app_class",
     "apply_profiles",
     "browser_layers",
     "controlpanel_actions",
     "create_content",
+    "create_site",
+    "distribution_name",
     "functional_app",
     "functional_app_class",
     "functional_http_request",
@@ -84,6 +87,9 @@ OUR_FIXTURES = [
     "profile_last_version",
     "request_factory",
     "setup_tool",
+    "site_logo",
+    "site_owner_name",
+    "site_owner_password",
 ]
 
 

--- a/tests/fixtures/test_distribution.py
+++ b/tests/fixtures/test_distribution.py
@@ -1,0 +1,95 @@
+"""Tests for plone.distribution fixtures."""
+
+import pytest
+
+
+# A conftest whose layer comes from ``plone.distribution.testing``: it registers
+# the ``testing`` distribution (loading its ZCML and the products it needs) and
+# creates a base site. ``create_site`` then builds a second site from the same
+# distribution. Requires ``plone.app.caching`` and ``plone.volto`` (test deps).
+DISTRIBUTION_CONFTEST = """
+    from plone.distribution.testing import INTEGRATION_TESTING
+    from pytest_plone import fixtures_factory
+
+    pytest_plugins = ["pytest_plone"]
+
+    globals().update(fixtures_factory(((INTEGRATION_TESTING, "integration"),)))
+"""
+
+
+@pytest.mark.no_cover
+class TestDistributionDefaults:
+    """Default values of the plone.distribution helper fixtures."""
+
+    def test_distribution_name(self, testdir):
+        testdir.makepyfile(
+            """
+            def test_name(distribution_name):
+                assert distribution_name == "testing"
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=1)
+
+    def test_answers(self, testdir):
+        testdir.makepyfile(
+            """
+            def test_default_answers(answers):
+                assert answers["site_id"] == "plone-site"
+                assert answers["setup_content"] is False
+                assert answers["site_logo"]
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=1)
+
+    def test_site_owner_fixtures(self, testdir):
+        testdir.makepyfile(
+            """
+            from plone.app.testing import SITE_OWNER_NAME, SITE_OWNER_PASSWORD
+
+            def test_owner(site_owner_name, site_owner_password):
+                assert site_owner_name == SITE_OWNER_NAME
+                assert site_owner_password == SITE_OWNER_PASSWORD
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=1)
+
+
+@pytest.mark.no_cover
+class TestCreateSite:
+    """``create_site`` creates a Plone site from a distribution."""
+
+    def test_create_site(self, testdir):
+        testdir.makeconftest(DISTRIBUTION_CONFTEST)
+        testdir.makepyfile(
+            """
+            from plone import api
+
+            def test_site_created(create_site, app, answers):
+                site = create_site(app, answers)
+                assert site.getId() == "plone-site"
+                assert site.title == "Plone Site"
+                # Set as the current local site
+                assert api.portal.get() is site
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=1)
+
+    def test_create_site_is_idempotent(self, testdir):
+        testdir.makeconftest(DISTRIBUTION_CONFTEST)
+        testdir.makepyfile(
+            """
+            def test_recreate(create_site, app, answers):
+                first = create_site(app, answers)
+                assert "plone-site" in app.objectIds()
+                # Calling again deletes the existing site and recreates it
+                second = create_site(app, answers)
+                assert app.objectIds().count("plone-site") == 1
+                assert second.getId() == "plone-site"
+            """
+        )
+        result = testdir.runpytest_subprocess()
+        result.assert_outcomes(passed=1)


### PR DESCRIPTION
## What

Adds `plone.distribution` support to pytest-plone: fixtures to create a Plone site from a distribution in tests.

### New fixtures

| Fixture | Scope | Description |
| --- | --- | --- |
| `create_site` | session | Callable `func(app, answers) -> PloneSite` that creates a **new** site from a distribution, deleting any existing site with the same `site_id` first, and sets it as the current local site. |
| `distribution_name` | session | Name of the distribution to create sites from (default `"testing"`). Override in your `conftest.py`. |
| `answers` | session | Mapping of answers passed to the distribution handler (site id, title, language, ...). Override to customize. |
| `site_logo` | session | Data-URI logo used as the `site_logo` answer. |
| `site_owner_name` / `site_owner_password` | session | Accessors for `SITE_OWNER_NAME` / `SITE_OWNER_PASSWORD`, so tests and fixtures can depend on them instead of importing the constants. |

`create_site` uses the private `plone.distribution.api.site._create_site` to **avoid committing**, so the testing layer still isolates each test. The created site coexists with the site provided by the testing layer (a second site, by design).

### Types

Adds a `SiteCreator` Protocol in `_types.py` (callable-fixture return type, following the existing convention).

## Dependencies

- Runtime: `plone.distribution`, `plone.exportimport`
- Test: `plone.app.caching`, `plone.volto` — required because the `testing` distribution from `plone.distribution.testing` (used to exercise `create_site`) applies their GenericSetup profiles.

## Testing

- New `tests/fixtures/test_distribution.py`: default-value checks for the helper fixtures, and `create_site` functional tests (site created + idempotent re-create) against the `testing` distribution loaded from `plone.distribution.testing`.
- Full suite: 82 passed
- `uvx mypy src` clean, `ruff` clean
- `news/58.feature` added

Closes #58