### PR TITLE
Apply ruff format to the Markdown code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,10 @@ pytest_plugins = ["pytest_plone"]
 
 
 globals().update(
-    fixtures_factory(
-        (
-            (MY_ADDON_FUNCTIONAL_TESTING, "functional"),
-            (MY_ADDON_INTEGRATION_TESTING, "integration"),
-        )
-    )
+    fixtures_factory((
+        (MY_ADDON_FUNCTIONAL_TESTING, "functional"),
+        (MY_ADDON_INTEGRATION_TESTING, "integration"),
+    ))
 )
 ```
 

--- a/docs/how-to/set-up-pytest-plone.md
+++ b/docs/how-to/set-up-pytest-plone.md
@@ -45,12 +45,10 @@ pytest_plugins = ["pytest_plone"]
 
 
 globals().update(
-    fixtures_factory(
-        (
-            (MY_ADDON_FUNCTIONAL_TESTING, "functional"),
-            (MY_ADDON_INTEGRATION_TESTING, "integration"),
-        )
-    )
+    fixtures_factory((
+        (MY_ADDON_FUNCTIONAL_TESTING, "functional"),
+        (MY_ADDON_INTEGRATION_TESTING, "integration"),
+    ))
 )
 ```
 

--- a/docs/how-to/speed-up-the-test-suite.md
+++ b/docs/how-to/speed-up-the-test-suite.md
@@ -26,7 +26,7 @@ This is the single most expensive mistake available to you—it has been measure
 If you see this symptom, check that you have not disabled that:
 
 ```python
-fixtures_factory(layers, keep_session=False)   # <- this reintroduces the problem
+fixtures_factory(layers, keep_session=False)  # <- this reintroduces the problem
 ```
 
 Remove the `keep_session=False`.

--- a/docs/tutorials/first-test.md
+++ b/docs/tutorials/first-test.md
@@ -42,12 +42,10 @@ pytest_plugins = ["pytest_plone"]
 
 
 globals().update(
-    fixtures_factory(
-        (
-            (MY_ADDON_FUNCTIONAL_TESTING, "functional"),
-            (MY_ADDON_INTEGRATION_TESTING, "integration"),
-        )
-    )
+    fixtures_factory((
+        (MY_ADDON_FUNCTIONAL_TESTING, "functional"),
+        (MY_ADDON_INTEGRATION_TESTING, "integration"),
+    ))
 )
 ```
 

--- a/news/+ruff-format-markdown.internal
+++ b/news/+ruff-format-markdown.internal
@@ -1,0 +1,1 @@
+Reformat the Python code blocks in the docs and README with the current ``ruff``, which now formats fenced code inside Markdown. Keeps the unpinned lint CI green. @jensens


### PR DESCRIPTION
The `lint` job started failing on `main`: `ruff@latest format --diff` reports *4 files would be reformatted*.

The lint CI runs `ruff@latest` unpinned, and a recent ruff now formats Python code blocks **inside Markdown**. Four snippets (`README.md` and three `docs/` pages) predate that behavior, so this reformats them.

No content change — only whitespace/paren layout in the fenced examples. `ruff format --diff` and `ruff check` are clean afterwards.